### PR TITLE
ci: assert SULO's logical properties on every change to sulo.ttl

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,42 @@
+# Regression and competency-question suite for sulo.ttl.
+#
+# Complements the existing checks rather than replacing them. `syntax_check`
+# asks whether the ontology parses; `reasoning` asks whether it is consistent
+# as a whole. Neither notices when a specific subsumption stops holding, a
+# disjointness axiom stops excluding anything, or the PRO role chain stops
+# firing: the ontology still parses and is still consistent, so the regression
+# ships silently. This job asserts those properties individually.
+#
+# It downloads a prebuilt, pinned binary and the suite that was tested with it,
+# so no Rust toolchain is installed here.
+name: Regression suite
+
+on:
+  push:
+    paths:
+      - 'sulo.ttl'
+      - '.github/workflows/regression.yml'
+  # Also on pull requests, deliberately. The existing reasoning job runs only
+  # on push, so today a regression is caught after it has already landed on the
+  # branch. Running here means a change to sulo.ttl is checked before merge.
+  pull_request:
+    paths:
+      - 'sulo.ttl'
+      - '.github/workflows/regression.yml'
+  workflow_dispatch:
+
+jobs:
+  regression:
+    name: Assert SULO's logical properties
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Pinned to a tag on purpose: a moving version is a moving oracle, and a
+      # suite that changed under you is indistinguishable from an ontology that
+      # changed under you.
+      - name: Run the SULO test harness
+        uses: MaastrichtU-IDS/sulo-testharness@v0.1.0
+        with:
+          ontology: sulo.ttl

--- a/sulo.ttl
+++ b/sulo.ttl
@@ -352,6 +352,7 @@ sulo:Object a owl:Class ;
         [ a owl:Restriction ;
             owl:allValuesFrom sulo:Object ;
             owl:onProperty sulo:hasPart ] ;
+    owl:disjointWith sulo:Process ;
     skos:example "a heart, the function to pump blood, the role of a doctor"@en .
 
 sulo:hasPart a owl:ObjectProperty,

--- a/sulo.ttl
+++ b/sulo.ttl
@@ -352,7 +352,6 @@ sulo:Object a owl:Class ;
         [ a owl:Restriction ;
             owl:allValuesFrom sulo:Object ;
             owl:onProperty sulo:hasPart ] ;
-    owl:disjointWith sulo:Process ;
     skos:example "a heart, the function to pump blood, the role of a doctor"@en .
 
 sulo:hasPart a owl:ObjectProperty,


### PR DESCRIPTION
Adds a CI job that regression-tests SULO's logical properties, complementing the checks already here rather than replacing them.

### Why

`syntax_check` asks whether the ontology parses. `reasoning` asks whether it is consistent as a whole. Neither notices when a specific subsumption stops holding, a disjointness axiom stops excluding anything, or the PRO role chain stops firing. In all of those cases `sulo.ttl` still parses, still comes back consistent, and the regression ships silently.

This job asserts those properties one at a time: **66 cases across six groups** (taxonomy, properties, restrictions, domains and ranges, and the PRO and SOLID patterns).

### Why you can trust the suite

A test suite that cannot fail is worse than none, because it produces confident green. So the suite is itself guarded by **10 mutants**, each a single documented edit to `sulo.ttl`. Every mutation test requires *both* directions: the case must pass on clean SULO **and** fail on the mutant. Every group has at least one caught mutant, and both competency questions are mutation proven.

The mutants are re-derived from a live read of `sulo.ttl` on every harness run and compared byte for byte, so a SULO change the mutants do not reflect is a build failure rather than a suite quietly testing a frozen ontology.

### It does not overstate what it verified

The harness uses a sound but incomplete reasoner, so "not entailed" is an absence of proof rather than a proof of absence. It reports four verdicts, not two: a negative expectation the reasoner merely failed to refute is reported as `UnrefutedPass`, never as a pass. A timeout or an axiom the reasoner could not represent is `Indeterminate`, never a silent green.

One case is deliberately **not** run: `TimeInstant subClassOf (hasValue only (xsd:dateTime or xsd:dateTimeStamp))` is a data range the pinned reasoner provably cannot enforce, and `sulo.ttl` logs that axiom as lost on every load. Reporting it as a failure would claim SULO regressed when the reasoner simply cannot see the axiom. It is named and counted in the report, excluded from the exit code, and will be picked up by a HermiT differential job.

### Cost

No Rust toolchain is installed. The action downloads a prebuilt static binary and the suite that was tested with it, both from a pinned release. Runtime is a couple of minutes.

Pinned to `v0.1.0` on purpose: a moving version is a moving oracle, and a suite that changed under you is indistinguishable from an ontology that changed under you. Bumping the pin is a deliberate, reviewable commit.

### One difference from the existing jobs

This also runs on `pull_request`. `reasoning` currently runs only on `push`, so a regression is caught after it has landed on the branch. Running here means a change to `sulo.ttl` is checked before merge. The workflow file is in its own `paths` filter, so this PR exercises the job itself.

### Related

Harness: [MaastrichtU-IDS/sulo-testharness](https://github.com/MaastrichtU-IDS/sulo-testharness). Building it also produced #5 (redundant and semantically inert axioms) and a set of corrections to the FOUST 2025 paper's listings, now in [MaastrichtU-IDS/sulo-foust2025-manuscript](https://github.com/MaastrichtU-IDS/sulo-foust2025-manuscript).