### PR TITLE
ci: do not fail the badge job when the badge has not changed

### DIFF
--- a/.github/workflows/version-badge.yml
+++ b/.github/workflows/version-badge.yml
@@ -32,5 +32,13 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git add version.svg
-          git commit -m "Update ontology version badge"
-          git push
+          # `git commit` exits 1 when nothing is staged, which is the normal
+          # case: the badge only changes when the ontology version does, so
+          # every push that touches sulo.ttl without a version bump failed
+          # this job. Commit and push only when there is actually a change.
+          if git diff --staged --quiet; then
+            echo "version badge unchanged; nothing to commit"
+          else
+            git commit -m "Update ontology version badge"
+            git push
+          fi


### PR DESCRIPTION
One line of logic. `Generate Ontology Version Badge` fails on any push that touches `sulo.ttl` without changing the ontology version.

### Cause

`.github/workflows/version-badge.yml`:

```yaml
git add version.svg
git commit -m "Update ontology version badge"
git push
```

`git commit` exits 1 when nothing is staged, and the step has no guard. `version.svg` only changes when the version does, so a push that edits `sulo.ttl` without a version bump stages nothing and the job fails with `nothing to commit, working tree clean`.

It has looked healthy because the pushes that reached it in the past did bump the version, so something was always staged.

### How it surfaced

While verifying the regression suite in #6, I pushed `sulo.ttl` twice on a branch (a deliberate one-axiom break, then its revert) to prove the new job could go red. Net change to the ontology: none. Net change to the badge: none. The badge job failed both times, on a branch whose `sulo.ttl` is byte-identical to `main`.

### Fix

Commit and push only when something is staged, and log it when nothing is:

```yaml
git add version.svg
if git diff --staged --quiet; then
  echo "version badge unchanged; nothing to commit"
else
  git commit -m "Update ontology version badge"
  git push
fi
```

Verified in a scratch repository in both directions: an unchanged `version.svg` takes the skip branch and exits 0, a changed one takes the commit branch. `version-badge.yml` still parses.

Deliberately kept separate from #6, since mixing an unrelated CI fix into a feature branch makes both harder to review.